### PR TITLE
Add autowired repositories

### DIFF
--- a/app/lib/autowired_repository.rb
+++ b/app/lib/autowired_repository.rb
@@ -1,0 +1,31 @@
+module AutowiredRepository
+  # Solution inspired by Java's Hibernate annotiations, which allow using repositories as domain objects
+  # The domain objects are automatically replaced with implementations on usage
+  # Example may be found in https://github.com/VaughnVernon/IDDD_Samples - implementation of examples from the Red Book
+
+  # Java Example description
+  # Application layer uses repository as a domain object
+  # https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/main/java/com/saasovation/identityaccess/application/AccessApplicationService.java#L25
+  # Even though this domain object is just an interface
+  # https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/main/java/com/saasovation/identityaccess/domain/model/identity/GroupRepository.java
+  # The repository is automatically wired to inMemory implementation in test env
+  # https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/test/resources/applicationContext-identityaccess-test.xml#L35
+  # The repository is automatically wired to Hibernate implementation in other envs
+  # https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/main/resources/applicationContext-identityaccess.xml#L33
+
+  def get
+    self.name.gsub('::Domain::', "::Infrastructure::#{wire_type}").constantize.new
+  end
+
+  # This way of defining repository implementations doesn't scale well for a bigger application
+  # However, this is just an example - this may be done with JSONs, YMLs, meta programing or any other solution
+  def wire_type
+    return 'Db' unless Rails.env.test?
+
+    if self.name == 'CooperationNegotiation::Domain::ContractRepository'
+      'InMemory'
+    else
+      'Db'
+    end
+  end
+end

--- a/app/modules/cooperation_negotiation/application/modify_contract_text_service.rb
+++ b/app/modules/cooperation_negotiation/application/modify_contract_text_service.rb
@@ -1,8 +1,8 @@
 module CooperationNegotiation
   module Application
     class ModifyContractTextService
-      def initialize(repository: Infrastructure::DbContractRepository.new)
-        self.repository = repository
+      def initialize
+        self.repository = Domain::ContractRepository.get
       end
 
       def call(contract_id:, text:)

--- a/app/modules/cooperation_negotiation/application/prepare_draft_contract_service.rb
+++ b/app/modules/cooperation_negotiation/application/prepare_draft_contract_service.rb
@@ -1,8 +1,8 @@
 module CooperationNegotiation
   module Application
     class PrepareDraftContractService
-      def initialize(repository: Infrastructure::DbContractRepository.new)
-        self.repository = repository
+      def initialize
+        self.repository = Domain::ContractRepository.get
       end
 
       def call(client_id:)

--- a/app/modules/cooperation_negotiation/application/sign_contract_by_client_service.rb
+++ b/app/modules/cooperation_negotiation/application/sign_contract_by_client_service.rb
@@ -1,8 +1,8 @@
 module CooperationNegotiation
   module Application
     class SignContractByClientService
-      def initialize(repository: Infrastructure::DbContractRepository.new)
-        self.repository = repository
+      def initialize
+        self.repository = Domain::ContractRepository.get
       end
 
       def call(contract_id:)

--- a/app/modules/cooperation_negotiation/application/sign_contract_by_company_service.rb
+++ b/app/modules/cooperation_negotiation/application/sign_contract_by_company_service.rb
@@ -1,8 +1,8 @@
 module CooperationNegotiation
   module Application
     class SignContractByCompanyService
-      def initialize(repository: Infrastructure::DbContractRepository.new)
-        self.repository = repository
+      def initialize
+        self.repository = Domain::ContractRepository.get
       end
 
       def call(contract_id:)

--- a/app/modules/cooperation_negotiation/domain/contract_repository.rb
+++ b/app/modules/cooperation_negotiation/domain/contract_repository.rb
@@ -1,0 +1,7 @@
+module CooperationNegotiation
+  module Domain
+    class ContractRepository
+      extend AutowiredRepository
+    end
+  end
+end

--- a/app/modules/cooperation_negotiation/infrastructure/in_memory_contract_repository.rb
+++ b/app/modules/cooperation_negotiation/infrastructure/in_memory_contract_repository.rb
@@ -5,15 +5,15 @@ module CooperationNegotiation
 
       def initialize(event_store_write: ::EventStore::Write.new)
         @event_store_write = event_store_write
-        @memory = {}
+        @@memory ||= {}
       end
 
       def of_id(id)
-        @memory[id]
+        @@memory[id]
       end
 
       def of_client_id(client_id)
-        @memory.each do |id, contract|
+        @@memory.each do |id, contract|
           return contract if contract.client_id == client_id
         end
 
@@ -25,7 +25,7 @@ module CooperationNegotiation
 
         contract.send('id=', id)
 
-        @memory[id] = contract
+        @@memory[id] = contract
         commit_events(contract)
       end
 

--- a/app/modules/dragon_hunt/application/handlers/cooperation_negotiation/contract_signed.rb
+++ b/app/modules/dragon_hunt/application/handlers/cooperation_negotiation/contract_signed.rb
@@ -3,7 +3,8 @@ module DragonHunt
     module Handlers
       module CooperationNegotiation
         class ContractSigned
-          def self.call(event, repository = Infrastructure::DbPartyRepository.new)
+          def self.call(event)
+            repository = Domain::PartyRepository.get
             party = Domain::Party.assemble(client_id: event.client_id)
 
             repository.save(party)

--- a/app/modules/dragon_hunt/domain/party_repository.rb
+++ b/app/modules/dragon_hunt/domain/party_repository.rb
@@ -1,0 +1,7 @@
+module DragonHunt
+  module Domain
+    class PartyRepository
+      extend AutowiredRepository
+    end
+  end
+end

--- a/app/modules/dragon_hunt/infrastructure/db_party_repository.rb
+++ b/app/modules/dragon_hunt/infrastructure/db_party_repository.rb
@@ -8,6 +8,13 @@ module DragonHunt
         Domain::Party.new(id: id, client_id: db_party.client_id)
       end
 
+      def of_client_id(client_id)
+        db_party = DbParty.find_by(client_id: client_id)
+        return unless db_party
+
+        Domain::Party.new(id: db_party.id, client_id: db_party.client_id)
+      end
+
       def save(party)
         db_party = DbParty.find_by(id: party.id) if party.id
         db_party ||= DbParty.new(id: party.id)

--- a/spec/modules/cooperation_negotiation/application/modify_contract_text_service_spec.rb
+++ b/spec/modules/cooperation_negotiation/application/modify_contract_text_service_spec.rb
@@ -4,7 +4,7 @@ module CooperationNegotiation
   module Application
     describe ModifyContractTextService do
       let(:client_id) { '00000000-0000-0000-0000-000000000001' }
-      let(:repository) { Infrastructure::InMemoryContractRepository.new }
+      let(:repository) { Domain::ContractRepository.get }
 
       describe '.call' do
         it 'prepares a draft contract' do
@@ -13,7 +13,7 @@ module CooperationNegotiation
 
           contract_id = contract.id
 
-          service = described_class.new(repository: repository)
+          service = described_class.new
           service.call(contract_id:, text: 'Modified content')
 
           contract = repository.of_id(contract_id)

--- a/spec/modules/cooperation_negotiation/application/prepare_draft_contract_service_spec.rb
+++ b/spec/modules/cooperation_negotiation/application/prepare_draft_contract_service_spec.rb
@@ -3,12 +3,12 @@ require_relative "../../../rails_helper"
 module CooperationNegotiation
   module Application
     describe PrepareDraftContractService do
+      let(:client_id) { '00000000-0000-0000-0000-000000000001' }
+      let(:repository) { Domain::ContractRepository.get }
+
       describe '.call' do
         it 'prepares a draft contract' do
-          client_id = '00000000-0000-0000-0000-000000000001'
-          repository = Infrastructure::InMemoryContractRepository.new
-
-          service = described_class.new(repository: repository)
+          service = described_class.new
           service.call(client_id:)
 
           expect(repository.of_client_id(client_id)).to be_present

--- a/spec/modules/cooperation_negotiation/application/sign_contract_by_client_service_spec.rb
+++ b/spec/modules/cooperation_negotiation/application/sign_contract_by_client_service_spec.rb
@@ -4,7 +4,7 @@ module CooperationNegotiation
   module Application
     describe SignContractByClientService do
       let(:client_id) { '00000000-0000-0000-0000-000000000001' }
-      let(:repository) { Infrastructure::InMemoryContractRepository.new }
+      let(:repository) { Domain::ContractRepository.get }
 
       describe '.call' do
         it 'adds client signature' do
@@ -13,7 +13,7 @@ module CooperationNegotiation
 
           contract_id = contract.id
 
-          service = described_class.new(repository: repository)
+          service = described_class.new
           service.call(contract_id:)
 
           contract = repository.of_id(contract_id)

--- a/spec/modules/cooperation_negotiation/application/sign_contract_by_company_service_spec.rb
+++ b/spec/modules/cooperation_negotiation/application/sign_contract_by_company_service_spec.rb
@@ -4,7 +4,7 @@ module CooperationNegotiation
   module Application
     describe SignContractByCompanyService do
       let(:client_id) { '00000000-0000-0000-0000-000000000001' }
-      let(:repository) { Infrastructure::InMemoryContractRepository.new }
+      let(:repository) { Domain::ContractRepository.get }
 
       describe '.call' do
         it 'adds company signature' do
@@ -13,7 +13,7 @@ module CooperationNegotiation
 
           contract_id = contract.id
 
-          service = described_class.new(repository: repository)
+          service = described_class.new
           service.call(contract_id:)
 
           contract = repository.of_id(contract_id)

--- a/spec/modules/dragon_hunt/application/handlers/cooperation_negotiation/contract_signed_spec.rb
+++ b/spec/modules/dragon_hunt/application/handlers/cooperation_negotiation/contract_signed_spec.rb
@@ -6,16 +6,16 @@ module DragonHunt
       module CooperationNegotiation
         describe ContractSigned do
           describe '.call' do
-            it 'saves the party' do
-              id = '001'
-              client_id = '002'
+            let(:id) { '00000000-0000-0000-0000-000000000001' }
+            let(:client_id) { '00000000-0000-0000-0000-000000000002' }
 
-              repository = instance_double(Infrastructure::DbPartyRepository, save: true)
+            it 'saves the party' do
               event = ::CooperationNegotiation::Domain::Events::ContractSigned.new
               event.client_id = client_id
-              described_class.call(event, repository)
+              described_class.call(event)
 
-              expect(repository).to have_received(:save).with(Domain::Party.new(client_id:))
+              repository = Domain::PartyRepository.get
+              expect(repository.of_client_id(client_id)).to be_present
             end
           end
         end


### PR DESCRIPTION
## Idea
The solution is inspired by Java's Hibernate annotations, which allows to use repositories as domain objects. The domain objects are automatically replaced with implementations on usage. The definition of which repository implementation should be use in which case is defined in a set of XML files.

It allows using (for example) relational databases as persistence mechanism in development and production but in-memory persistence for tests.

Example may be found in https://github.com/VaughnVernon/IDDD_Samples - implementation of examples from the Red Book

## Java example
- Application layer uses repository as a domain object: https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/main/java/com/saasovation/identityaccess/application/AccessApplicationService.java#L25
- Even though this domain object is just an interface: https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/main/java/com/saasovation/identityaccess/domain/model/identity/GroupRepository.java
- The repository is automatically wired to inMemory implementation in test env: https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/test/resources/applicationContext-identityaccess-test.xml#L35
- The repository is automatically wired to Hibernate implementation in other envs: https://github.com/VaughnVernon/IDDD_Samples/blob/master/iddd_identityaccess/src/main/resources/applicationContext-identityaccess.xml#L33

## Ruby example
- Application layer uses repository as a domain object and fetches an instance by using `.get` method: app/modules/cooperation_negotiation/application/prepare_draft_contract_service.rb
- Repository class uses `AutowiredRepository` module to extend its capabilities and be able to auto-wire a proper implementation
- `AutowiredRepository` module returns a proper implementation of the repository, from the infrastructure level
- The repository is automatically wired to inMemory implementation in the test env: app/modules/cooperation_negotiation/infrastructure/in_memory_contract_repository.rb
- The repository is automatically wired to ActiveRecord-based implementation in other envs: app/modules/cooperation_negotiation/infrastructure/db_contract_repository.rb