### PR TITLE
[Issue #2] Adjust Authorization::Application::Api.identity_in_role? and fix seeds

### DIFF
--- a/app/modules/authorization/application/api.rb
+++ b/app/modules/authorization/application/api.rb
@@ -3,7 +3,7 @@ module Authorization
     class Api
       def self.identity_in_role?(identity, role_name)
         return true if identity == '00000000-0000-0000-0000-000000000001' && role_name == 'admin'
-        return true if identity == '00000000-0000-0000-0000-000000000005' && role_name == 'client'
+        return true if identity.to_s.match(/\h{8}-(\h{4}-){3}\h{12}/) && role_name == 'client'
 
         false
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,20 +2,22 @@ def print_header(label)
   puts "\n========================\n== #{label}"
 end
 
-contract_repository = CooperationNegotiation::Infrastructure::DbContractRepository.new
+contract_repository = CooperationNegotiation::Domain::ContractRepository.get
 
-client_id = '00000000-0000-0000-0000-000000000001'
-CooperationNegotiation::Application::Services::PrepareDraftContract.new.call(client_id: client_id)
+admin_identity = '00000000-0000-0000-0000-000000000001'
+
+client_id = '00000000-0000-0000-0000-000000000007'
+CooperationNegotiation::Application::Services::PrepareDraftContract.new.call(identity: admin_identity, client_id: client_id)
 contract = contract_repository.of_client_id(client_id)
 CooperationNegotiation::Application::Services::ModifyContractText.new.call(contract_id: contract.id, text: 'foo foo')
 
-client_id = '00000000-0000-0000-0000-000000000002'
-CooperationNegotiation::Application::Services::PrepareDraftContract.new.call(client_id: client_id)
+client_id = '00000000-0000-0000-0000-000000000008'
+CooperationNegotiation::Application::Services::PrepareDraftContract.new.call(identity: admin_identity, client_id: client_id)
 contract = contract_repository.of_client_id(client_id)
 CooperationNegotiation::Application::Services::SignContractByClient.new.call(contract_id: contract.id)
 
-client_id = '00000000-0000-0000-0000-000000000003'
-CooperationNegotiation::Application::Services::PrepareDraftContract.new.call(client_id: client_id)
+client_id = '00000000-0000-0000-0000-000000000009'
+CooperationNegotiation::Application::Services::PrepareDraftContract.new.call(identity: admin_identity, client_id: client_id)
 contract = contract_repository.of_client_id(client_id)
 CooperationNegotiation::Application::Services::ModifyContractText.new.call(contract_id: contract.id, text: 'The correct one')
 CooperationNegotiation::Application::Services::SignContractByClient.new.call(contract_id: contract.id)

--- a/spec/modules/authorization/application/api_spec.rb
+++ b/spec/modules/authorization/application/api_spec.rb
@@ -8,7 +8,7 @@ module Authorization
           let(:identity) { '00000000-0000-0000-0000-000000000001' }
 
           it { expect(described_class.identity_in_role?(identity, 'admin')).to be true }
-          it { expect(described_class.identity_in_role?(identity, 'client')).to be false }
+          it { expect(described_class.identity_in_role?(identity, 'client')).to be true }
           it { expect(described_class.identity_in_role?(identity, 'foo')).to be false }
         end
 
@@ -20,12 +20,12 @@ module Authorization
           it { expect(described_class.identity_in_role?(identity, 'foo')).to be false }
         end
 
-        context 'when checking a random identity' do
-          let(:identity) { '11112222-0000-0000-0000-000000000000' }
+        context 'when checking a non-uuid identity' do
+          let(:identity) { 'foo' }
 
           it { expect(described_class.identity_in_role?(identity, 'client')).to be false }
           it { expect(described_class.identity_in_role?(identity, 'admin')).to be false }
-          it { expect(described_class.identity_in_role?(identity, 'foo')).to be false }
+          it { expect(described_class.identity_in_role?(identity, 'bar')).to be false }
         end
       end
     end


### PR DESCRIPTION
As pointed out in #2 , there was a problem with running `db:seed`. It has been the case because the previous change was introduced hastily and without proper care.

Apart from fixing the logic in seeds file, this adjusts the (simulated) logic for checking whether an identity is in `Authorization::Application::Api.identity_in_role?`.

The authorization functionality needs further work, the so far changes were merely a PoC for an authorization approach.

